### PR TITLE
JCN 176 Crear Package Redis

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
 		'no-underscore-dangle': ['warn', {
 			allowAfterThis: true,
 			allowAfterSuper: true,
-			allow: ['_call', '__rootpath', '_where']
+			allow: ['_call', '__rootpath', '_where', '_client', '_config']
 		}],
 
 		'no-tabs': 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Unit Tests
+- `Redis`
+- Documentation

--- a/README.md
+++ b/README.md
@@ -8,13 +8,121 @@
 npm install @janiscommerce/redis --save
 ```
 
+## Configuration
+This package uses [@janiscommerce/settings](https://www.npmjs.com/package/@janiscommerce/settings). 
+
+In `.janiscommercerc.json` file could have the configuration, under `"redis"` key and `"host"` and / or `"port"` values (both optionals).
+
+### Example
+```json
+{
+    "redis": {
+        "host": "redis.example.host",
+        "port": 4040
+    }
+}
+```
+
+### Defaults
+If there isn't any settings the `host` and `port` would be default:
+- `host`: `localhost`
+- `port`: `6379`
+
 ## API
 
+### `set(entity, id, value)`
+
+**async** | Saved or Updated a value.
+
+* `entity`, type: `string`, main key.
+* `id`, type: `string`, sub key.
+* `value`, type: `object`, value to be saved.
+
+Returns an `integer`:
+* `1`, saved a new value
+* `0`, updated a value
+
+Throw an `RedisError` if Redis Server fails.
+
+### `get(entity, id)`
+
+**async** | Get a value.
+
+* `entity`, type: `string`, main key.
+* `id`, type: `string`, sub key.
+
+Returns an `object`, with the value. If it not exists returns `null`.
+
+Throw an `RedisError` if Redis Server fails.
+
+### `del(entity, id)` 
+
+**async** | Delete a value.
+
+* `entity`, type: `string`, main key.
+* `id`, type: `string`, sub key.
+
+Returns an `integer`:
+* `1`, delete de registry
+* `0`, no delete
+
+Throw an `RedisError` if Redis Server fails.
+
+## Errors
+
+The errors are informed with a `RedisError`.  
+This object has a code that can be useful for a correct error handling.  
+The codes are the following:  
+
+| Code | Description                    |
+|------|--------------------------------|
+| 1    | Connections Errors             |
+| 2    | Errors trying to Set           |
+| 3    | Errors trying to Get           |
+| 4    | Errors trying to Delete        |
 
 ## Usage
 ```js
 const Redis = require('@janiscommerce/redis');
 
+// SET - Insert
+
+const itemProperties = {
+   name: 'BatGun' ,
+   description: 'not a gun'
+}
+
+let saved = await Redis.set('Batman', 'artifact-01', itemProperties);
+
+console.log(saved); // 1
+
+// SET - Update
+
+itemProperties.description = 'deprecated gun';
+
+saved = await Redis.set('Batman', 'artifact-01', itemProperties);
+
+console.log(saved) // 0
+
+// GET
+
+let itemGetted = await Redis.get('Batman', 'artifact-01');
+
+console.log(itemGetted); // { name: 'BatGun', description: 'deprecated gun' }
+
+itemGetted = await Redis.get('Batman', 'artifact-02');
+
+console.log(itemGetted); // null
+
+// DELETE
+
+let deleted = await Redis.del('Batman', 'artifact-01');
+
+console.log(deleted); // 1
+
+deleted = await Redis.del('Batman', 'artifact-01');
+
+console.log(deleted); // 0
+
 ```
 
-## Examples

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Throw an `RedisError` if Redis Server fails.
 **async** | Get a value.
 
 * `entity`, type: `string`, main key.
-* `id`, type: `string`, sub key.
+* `id`, type: `string`, sub key. *OPTIONAL*
 
-Returns an `object`, with the value. If it not exists returns `null`.
+With `ìd` - Returns an `object`, with the value. If it not exists returns `null`. 
+Without `ìd` - Returns an `array`, with the values of the Entity or an empty array (if no values are found)
 
 Throw an `RedisError` if Redis Server fails.
 
@@ -113,6 +114,14 @@ console.log(itemGetted); // { name: 'BatGun', description: 'deprecated gun' }
 itemGetted = await Redis.get('Batman', 'artifact-02');
 
 console.log(itemGetted); // null
+
+itemGetted = await Redis.get('Batman');
+
+console.log(itemGetted); // [{ name: 'BatGun', description: 'deprecated gun' }]
+
+itemGetted = await Redis.get('Joker');
+
+console.log(itemGetted); // []
 
 // DELETE
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const Redis = require('./redis');
-const RedisError = require('./redis-error');
-
-module.exports = {
-	Redis,
-	RedisError
-};

--- a/lib/redis-error.js
+++ b/lib/redis-error.js
@@ -5,7 +5,10 @@ class RedisError extends Error {
 	static get codes() {
 
 		return {
-			// your errors here...
+			CONNECTION_PROBLEM: 1,
+			SET_PROBLEM: 2,
+			GET_PROBLEM: 3,
+			DEL_PROBLEM: 4
 		};
 
 	}

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -51,14 +51,14 @@ class Redis {
 	/**
 	 * Insert or Update a value
 	 * @async
-	 * @param {string} key
-	 * @param {string} subKey
+	 * @param {string} entity
+	 * @param {string} id
 	 * @param {object} value Value to be Stored
 	 * @returns {integer} 1 = new value store, 0 = value updated
 	 */
-	static async set(key, subKey, value) {
+	static async set(entity, id, value) {
 		try {
-			const response = await this.client.hset(key, subKey, JSON.stringify(value));
+			const response = await this.client.hset(entity, id, JSON.stringify(value));
 			return response;
 		} catch(error) {
 			throw new RedisError(error, RedisError.codes.SET_PROBLEM);
@@ -68,13 +68,13 @@ class Redis {
 	/**
 	 * Get a value in Redis
 	 * @async
-	 * @param {string} key
-	 * @param {string} subKey
+	 * @param {string} entity
+	 * @param {string} id
 	 * @returns {object} Value Storaged
 	 */
-	static async get(key, subKey) {
+	static async get(entity, id) {
 		try {
-			const value = await this.client.hget(key, subKey);
+			const value = await this.client.hget(entity, id);
 			return value && JSON.parse(value);
 		} catch(error) {
 			throw new RedisError(error, RedisError.codes.GET_PROBLEM);
@@ -84,13 +84,13 @@ class Redis {
 	/**
 	 * Delete a value
 	 * @async
-	 * @param {string} key
-	 * @param {string} subKey
+	 * @param {string} entity
+	 * @param {string} id
 	 * @returns {integer} 0 = no delete, 1 = deleted
 	 */
-	static async del(key, subKey) {
+	static async del(entity, id) {
 		try {
-			const response = await this.client.hdel(key, subKey);
+			const response = await this.client.hdel(entity, id);
 			return response;
 		} catch(error) {
 			throw new RedisError(error, RedisError.codes.DEL_PROBLEM);

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,11 +1,101 @@
 'use strict';
 
+const { promisify } = require('util');
+
+const redis = require('redis');
+const Settings = require('@janiscommerce/settings');
+
 const RedisError = require('./redis-error');
+
+const SETTINGS_KEY = 'redis';
+const DEFAULT_HOST = 'localhost';
+const DEFAULT_PORT = 6379;
+
+const promisfyMethods = ['hget', 'hset', 'hdel'];
 
 class Redis {
 
-	// package code...
+	static get config() {
 
+		if(!this._config)
+			this._config = Settings.get(SETTINGS_KEY) || {};
+
+		return this._config;
+	}
+
+	static get client() {
+
+		if(!this._client) {
+			this._client = redis.createClient({
+				host: this.config.host || DEFAULT_HOST,
+				port: this.config.port || DEFAULT_PORT,
+				retry_strategy: options => {
+					if(options.error && options.error.code === 'ECONNREFUSED')
+						throw new RedisError(options.error, RedisError.codes.CONNECTION_PROBLEM);
+
+					if(options.attempt >= 3)
+						return undefined;
+
+					return 1000;
+				}
+			});
+
+			promisfyMethods.forEach(method => {
+				this._client[method] = promisify(this._client[method]);
+			});
+		}
+
+		return this._client;
+	}
+
+	/**
+	 * Insert or Update a value
+	 * @async
+	 * @param {string} key
+	 * @param {string} subKey
+	 * @param {object} value Value to be Stored
+	 * @returns {integer} 1 = new value store, 0 = value updated
+	 */
+	static async set(key, subKey, value) {
+		try {
+			const response = await this.client.hset(key, subKey, JSON.stringify(value));
+			return response;
+		} catch(error) {
+			throw new RedisError(error, RedisError.codes.SET_PROBLEM);
+		}
+	}
+
+	/**
+	 * Get a value in Redis
+	 * @async
+	 * @param {string} key
+	 * @param {string} subKey
+	 * @returns {object} Value Storaged
+	 */
+	static async get(key, subKey) {
+		try {
+			const value = await this.client.hget(key, subKey);
+			return value && JSON.parse(value);
+		} catch(error) {
+			throw new RedisError(error, RedisError.codes.GET_PROBLEM);
+		}
+	}
+
+	/**
+	 * Delete a value
+	 * @async
+	 * @param {string} key
+	 * @param {string} subKey
+	 * @returns {integer} 0 = no delete, 1 = deleted
+	 */
+	static async del(key, subKey) {
+		try {
+			const response = await this.client.hdel(key, subKey);
+			return response;
+		} catch(error) {
+			throw new RedisError(error, RedisError.codes.DEL_PROBLEM);
+		}
+	}
 }
 
 module.exports = Redis;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -11,7 +11,7 @@ const SETTINGS_KEY = 'redis';
 const DEFAULT_HOST = 'localhost';
 const DEFAULT_PORT = 6379;
 
-const promisfyMethods = ['hget', 'hset', 'hdel'];
+const promisfyMethods = ['hget', 'hset', 'hdel', 'hgetall'];
 
 class Redis {
 
@@ -69,13 +69,13 @@ class Redis {
 	 * Get a value in Redis
 	 * @async
 	 * @param {string} entity
-	 * @param {string} id
+	 * @param {string} id Optional
 	 * @returns {object} Value Storaged
 	 */
 	static async get(entity, id) {
 		try {
-			const value = await this.client.hget(entity, id);
-			return value && JSON.parse(value);
+			const value = id ? await this.client.hget(entity, id) : await this.client.hgetall(entity);
+			return id ? value && JSON.parse(value) : value.map(element => JSON.parse(element));
 		} catch(error) {
 			throw new RedisError(error, RedisError.codes.GET_PROBLEM);
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@janiscommerce/settings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/settings/-/settings-1.0.1.tgz",
+      "integrity": "sha512-BzB+m4+WYGhHepRxysW9i0Ndq6/5pAZEnPjHBM1BcgQ0WXUwhjyzPu3+lDJv9V9eUeaUNA4XcOTxYGNW78xBig=="
+    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,6 +451,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -2789,6 +2794,26 @@
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
       }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "regexpp": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@janiscommerce/settings": "^1.0.1",
     "redis": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@janiscommerce/redis",
   "version": "0.0.1",
   "description": "A Driver to use Redis",
-  "main": "lib/index.js",
+  "main": "lib/redis.js",
   "scripts": {
     "test": "export TEST_ENV=true; mocha --exit -R nyan --recursive tests/",
     "test-ci": "nyc --reporter=html --reporter=text mocha --recursive tests/",
@@ -31,5 +31,8 @@
   ],
   "directories": {
     "test": "tests"
+  },
+  "dependencies": {
+    "redis": "^2.8.0"
   }
 }

--- a/tests/redis-test.js
+++ b/tests/redis-test.js
@@ -81,7 +81,7 @@ describe('Redis', () => {
 
 	describe('Get', () => {
 
-		it('Should return null if a profile does not exist', async () => {
+		it('Should return null if an entity and id does not exist', async () => {
 
 			const redisClientStub = {
 				hget: sandbox.fake.resolves(null)
@@ -94,7 +94,7 @@ describe('Redis', () => {
 			assert.deepStrictEqual(value, null);
 		});
 
-		it('Should return the object if a profile is found', async () => {
+		it('Should return the object if an entity and id is found', async () => {
 
 			const redisClientStub = {
 				hget: sandbox.fake.resolves(JSON.stringify(sampleValue))
@@ -107,21 +107,49 @@ describe('Redis', () => {
 			assert.deepStrictEqual(value, sampleValue);
 		});
 
+		it('Should return an array of objects if an entity is found and no id is passed', async () => {
+
+			const redisClientStub = {
+				hgetall: sandbox.fake.resolves([JSON.stringify(sampleValue)])
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.get(sampleEntity);
+
+			assert.deepStrictEqual(value, [sampleValue]);
+		});
+
+		it('Should return an empty array of objects if an entity is not found and no id is passed', async () => {
+
+			const redisClientStub = {
+				hgetall: sandbox.fake.resolves([])
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.get(sampleEntity);
+
+			assert.deepStrictEqual(value, []);
+		});
+
 		it('Should reject if can not get', async () => {
 			const redisClientStub = {
-				hget: sandbox.fake.rejects()
+				hget: sandbox.fake.rejects(),
+				hgetall: sandbox.fake.rejects()
 			};
 
 			sandbox.stub(Redis, 'client').get(() => redisClientStub);
 
 			await assert.rejects(Redis.get(sampleEntity, sampleId), { code: RedisError.codes.GET_PROBLEM });
+			await assert.rejects(Redis.get(sampleEntity), { code: RedisError.codes.GET_PROBLEM });
 
 		});
 	});
 
 	describe('Delete', () => {
 
-		it('Should return 1 if a profile is deleted', async () => {
+		it('Should return 1 if an entity and id is deleted', async () => {
 
 			const redisClientStub = {
 				hdel: sandbox.fake.resolves(1)
@@ -134,7 +162,7 @@ describe('Redis', () => {
 			assert.deepStrictEqual(value, 1);
 		});
 
-		it('Should return 0 if a profile does not exist', async () => {
+		it('Should return 0 if an entity and id does not exist', async () => {
 
 			const redisClientStub = {
 				hdel: sandbox.fake.resolves(0)

--- a/tests/redis-test.js
+++ b/tests/redis-test.js
@@ -1,15 +1,291 @@
 'use strict';
 
 const assert = require('assert');
-
 const sandbox = require('sinon').createSandbox();
 
-const Redis = require('./../lib/index');
+const redis = require('redis');
+const Settings = require('@janiscommerce/settings');
 
-const RedisError = require('./../lib/redis-error');
+const Redis = require('../lib/redis');
+const RedisError = require('../lib/redis-error');
 
 describe('Redis', () => {
 
-	// your tests here...
+	const sampleEntity = 'Clients';
+	const sampleId = 'same-id';
+	const sampleValue = {
+		description: 'a sample',
+		keywords: ['sample', 'test']
+	};
 
+	let settingsStub;
+
+	beforeEach(() => {
+		settingsStub = sandbox.stub(Settings, 'get');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		delete Redis._client;
+		delete Redis._config;
+	});
+
+	describe('Set', () => {
+
+		it('Should return 1 if a new value is stored', async () => {
+
+			const redisClientStub = {
+				hset: sandbox.fake((key, subkey, value) => {
+					if(key !== sampleEntity || subkey !== sampleId || value !== JSON.stringify(sampleValue))
+						return -1;
+					return 1;
+				})
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.set(sampleEntity, sampleId, sampleValue);
+
+			assert.deepStrictEqual(value, 1);
+		});
+
+		it('Should return 0 if an existing value is updated', async () => {
+
+			const redisClientStub = {
+				hset: sandbox.fake((key, subkey, value) => {
+					if(key !== sampleEntity || subkey !== sampleId || value !== JSON.stringify(sampleValue))
+						return -1;
+					return 0;
+				})
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.set(sampleEntity, sampleId, sampleValue);
+
+			assert.deepStrictEqual(value, 0);
+		});
+
+		it('Should reject if can not set', async () => {
+
+			const redisClientStub = {
+				hset: sandbox.fake.rejects()
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			await assert.rejects(Redis.set(sampleEntity, sampleId, sampleValue), { code: RedisError.codes.SET_PROBLEM });
+
+		});
+	});
+
+	describe('Get', () => {
+
+		it('Should return null if a profile does not exist', async () => {
+
+			const redisClientStub = {
+				hget: sandbox.fake.resolves(null)
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.get(sampleEntity, sampleId);
+
+			assert.deepStrictEqual(value, null);
+		});
+
+		it('Should return the object if a profile is found', async () => {
+
+			const redisClientStub = {
+				hget: sandbox.fake.resolves(JSON.stringify(sampleValue))
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.get(sampleEntity, sampleId);
+
+			assert.deepStrictEqual(value, sampleValue);
+		});
+
+		it('Should reject if can not get', async () => {
+			const redisClientStub = {
+				hget: sandbox.fake.rejects()
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			await assert.rejects(Redis.get(sampleEntity, sampleId), { code: RedisError.codes.GET_PROBLEM });
+
+		});
+	});
+
+	describe('Delete', () => {
+
+		it('Should return 1 if a profile is deleted', async () => {
+
+			const redisClientStub = {
+				hdel: sandbox.fake.resolves(1)
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.del(sampleEntity, sampleId);
+
+			assert.deepStrictEqual(value, 1);
+		});
+
+		it('Should return 0 if a profile does not exist', async () => {
+
+			const redisClientStub = {
+				hdel: sandbox.fake.resolves(0)
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			const value = await Redis.del(sampleEntity, sampleId);
+
+			assert.deepStrictEqual(value, 0);
+		});
+
+		it('Should reject if can not delete', async () => {
+			const redisClientStub = {
+				hdel: sandbox.fake.rejects()
+			};
+
+			sandbox.stub(Redis, 'client').get(() => redisClientStub);
+
+			await assert.rejects(Redis.del(sampleEntity, sampleId), { code: RedisError.codes.DEL_PROBLEM });
+
+		});
+	});
+
+	describe('Client configuration', async () => {
+
+		const redisClientStub = sandbox.stub(redis.RedisClient.prototype);
+
+		it('Should pass the settings to the client', async () => {
+
+			settingsStub.returns({ host: 'some-host', port: 1234 });
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(({ host, port }) => {
+
+					assert.strictEqual(host, 'some-host');
+					assert.strictEqual(port, 1234);
+
+					return redisClientStub;
+				});
+
+			const { client } = Redis.client;
+
+			assert(client);
+		});
+
+		it('Should use default values if settings are not defined', async () => {
+
+			settingsStub.returns(null);
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(({ host, port }) => {
+
+					assert.strictEqual(host, 'localhost');
+					assert.strictEqual(port, 6379);
+
+					return redisClientStub;
+				});
+
+			const { client } = Redis.client;
+
+			assert(client);
+		});
+
+
+		it('Should create the redis client only once', async () => {
+
+			settingsStub.returns({ host: 'some-host', port: 1234 });
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(({ host, port }) => {
+
+					assert.strictEqual(host, 'some-host');
+					assert.strictEqual(port, 1234);
+
+					return redisClientStub;
+				});
+
+			const { client: client1 } = Redis.client;
+			const { client: client2 } = Redis.client;
+
+			assert(client1);
+			assert(client2);
+			assert(client1 === client2);
+
+			sandbox.assert.calledOnce(redis.createClient);
+		});
+
+		it('Should throw the received error if it is a connection error', async () => {
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(options => {
+
+					const connectionError = new Error('Connection error');
+					connectionError.code = 'ECONNREFUSED';
+
+					assert.throws(() => {
+						options.retry_strategy({
+							error: connectionError,
+							attempt: 1
+						});
+					}, { code: RedisError.codes.CONNECTION_PROBLEM, message: 'Connection error' });
+
+					return redisClientStub;
+				});
+
+			const { client } = Redis.client;
+
+			assert(client);
+		});
+
+		it('Should return the next connection timeout if attemps are lesser than 3', async () => {
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(options => {
+
+					const error = new Error('Some error');
+
+					const retryResponse = options.retry_strategy({
+						error,
+						attempt: 2
+					});
+					assert.strictEqual(retryResponse, 1000);
+
+					return redisClientStub;
+				});
+
+			const { client } = Redis.client;
+
+			assert(client);
+		});
+
+		it('Should return undefined if attemps are greater or equal to 3', async () => {
+
+			sandbox.stub(redis, 'createClient')
+				.callsFake(options => {
+
+					const error = new Error('Some error');
+
+					const retryResponse = options.retry_strategy({
+						error,
+						attempt: 3
+					});
+					assert.strictEqual(retryResponse, undefined);
+
+					return redisClientStub;
+				});
+
+			const { client } = Redis.client;
+
+			assert(client);
+		});
+	});
 });


### PR DESCRIPTION
**JCN-176-CREAR-PACKAGE-REDIS**
JCN-176 Crear Package Redis

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-176

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1. Crear nuevo package utilizando el repositorio https://github.com/janis-commerce/redis
 e instalandolo con `@janiscommerce/package-generator`

1.2. El package debe ofrecer wrapper de los siguientes métodos:

1.2.1. get, wrapper de `hget`

1.2.2. set, wrapper de `hset`

1.2.3. del, wrapper de `hdel`

1.3. Utilizar clase estática y cachear el cliente creado.

1.3.1. Crear el cliente en el primer método usado.

1.3.2. Utilizar las settings del valor `redis` utilizando el `@janiscommerce/settings`

1.3.3. Las settings tendrán el dato host para crear el cliente, ejemplo de settings:
```json
{
	"redis": {
		"host": "the-redis-host"
	}
}
```

1.4. El package debe estar 100% testeado para todas sus funcionalidades y escenarios

1.5. El package debe estar 100% documentado para todas sus funcionalidades y escenarios, mostrando ejemplos de uso.

_Comentarios extra:_

Eliminar el uso de `index.js`, exportar directamente el archivo `lib/redis.js`.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se creó el paquete pedido, con tests y documentación.
Agregué que se puedan gettear todos los valores de una entidad de una vez.