### PR TITLE
Jcn 471 fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The `connect()` allows to receive an object with the `url` as _String_ or _Strin
         -   This **won't** close the cached connection, the cached connection will persist and won't retry to connect.
             -   If you need to set a limit of retries but retry when your process is executed again, then `try catch` the error and use [closeConnection](#closeconnection)
             -   If you don't want it to retry connection until your process is restarted, then don't need to close the connection.
+    -   :new: `config.connectTimeout` optional _Number_ indicates the connection timeout in **miliseconds**. (Default: `5000`)
 
 #### Return
 * `client`: The Redis client when `host` is present in settings.
@@ -110,7 +111,10 @@ const Redis = require('@janiscommerce/redis');
 
     try {
 
-        const redisCluster = await Redis.connect({ maxRetries: 1 });
+        const redisCluster = await Redis.connect({
+            connectTimeout: 1000,
+            maxRetries: 1
+        });
 
     }catch(err) {
         console.log(err.message);

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ The `connect()` allows to receive an object with the `url` as _String_ or _Strin
 - `config` the optional configuration.
     -  `config.url` optional url as _String_ for connecting the client of cluster. _Since 2.3.0_
     -  `config.url` optional url as _String Array_ for connecting. Exclusive for in cluster mode. _Since 2.3.0_
-    -  :new: `config.maxRetries` optional _Number_ indicates the max amount of connection retries, when the max retries are reached the Client stops retrying and throws an error. (Default: `3`)
+    -  :new: `config.maxRetries` optional _Number_ indicates the max amount of connection retries. (Default: `3`)
+        -   When the max retries are reached the Client stops retrying and throws an [error](#errors)
+        -   This **won't** close the cached connection, the cached connection will persist and won't retry to connect.
+            -   If you need to set a limit of retries but retry when your process is executed again, then `try catch` the error and use [closeConnection](#closeconnection)
+            -   If you don't want it to retry connection until your process is restarted, then don't need to close the connection.
 
 #### Return
 * `client`: The Redis client when `host` is present in settings.
@@ -109,9 +113,21 @@ const Redis = require('@janiscommerce/redis');
         const redisCluster = await Redis.connect({ maxRetries: 1 });
 
     }catch(err) {
+        console.log(err.message);
         await Redis.closeConnection();
     }
 })();
 ```
+
+## Errors
+
+The errors are informed with a `RedisError`.
+This object has a code that can be useful for a debugging or error handling.
+The codes are the following:
+
+| Code | Description                        |
+|------|----------------------------------- |
+| 1    | Redis error                        |
+| 2    | Max connection retries reached     |
 
 > :information_source: For more examples see [redis](https://www.npmjs.com/package/redis)

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ The `connect()` allows to receive an object with the `url` as _String_ or _Strin
 
 **async** | Connects the Redis server using settings.
 
-#### Parameters
+#### :new: Parameters
 - `config` the optional configuration.
     -  `config.url` optional url as _String_ for connecting the client of cluster. _Since 2.3.0_
     -  `config.url` optional url as _String Array_ for connecting. Exclusive for in cluster mode. _Since 2.3.0_
+    -  :new: `config.maxRetries` optional _Number_ indicates the max amount of connection retries, when the max retries are reached the Client stops retrying and throws an error. (Default: `3`)
 
 #### Return
 * `client`: The Redis client when `host` is present in settings.
@@ -87,6 +88,19 @@ const Redis = require('@janiscommerce/redis');
 (async () => {
 
     const redisCluster = await Redis.connect();
+
+    await redisCluster.set('product-123', 'blue-shirt');
+
+    const value = await redisCluster.get('product-123');
+
+    // expected value: blue-shirt
+
+})();
+
+// Usage with custom max retries
+(async () => {
+
+    const redisCluster = await Redis.connect({ maxRetries: 1 });
 
     await redisCluster.set('product-123', 'blue-shirt');
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The `connect()` allows to receive an object with the `url` as _String_ or _Strin
 
 Throw an `Error` if Redis Server fails.
 
+### `closeConnection()`
+
+**async** | Closes the active connection.
+
 ## Usage
 ```js
 
@@ -100,14 +104,13 @@ const Redis = require('@janiscommerce/redis');
 // Usage with custom max retries
 (async () => {
 
-    const redisCluster = await Redis.connect({ maxRetries: 1 });
+    try {
 
-    await redisCluster.set('product-123', 'blue-shirt');
+        const redisCluster = await Redis.connect({ maxRetries: 1 });
 
-    const value = await redisCluster.get('product-123');
-
-    // expected value: blue-shirt
-
+    }catch(err) {
+        await Redis.closeConnection();
+    }
 })();
 ```
 

--- a/lib/redis-error.js
+++ b/lib/redis-error.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * @enum {number}
+ * @private
+ */
+const ERROR_CODES = {
+	REDIS_ERROR: 1, // Generic Redis Error
+	MAX_CONNECTION_RETRIES: 2 // Max connection retries reached
+};
+
+module.exports = class RedisError extends Error {
+
+	static get codes() {
+		return ERROR_CODES;
+	}
+
+	constructor(message, code, err) {
+
+		super(message);
+		this.message = message;
+		this.code = code;
+		this.name = this.constructor.name;
+
+		/* istanbul ignore else */
+		if(err && err instanceof Error)
+			this.previousError = err;
+	}
+};

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -106,8 +106,8 @@ module.exports = class Redis {
 
 	static retriesHandler(retries, maxRetries) {
 
-		// Redis retries count starts from 0 and does not count the first try
-		if(retries < (maxRetries - 1))
+		// Redis retries count starts from 0
+		if(retries < maxRetries)
 			return Math.min(retries * 50, 1000); // Redis default retry strategy (adds 50 miliseconds of wait per retry with a max of 1000)
 
 		return new Error(`Max connection retries (${maxRetries}) reached.`);

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -32,7 +32,13 @@ module.exports = class Redis {
 		return RedisError.codes;
 	}
 
-	static async connect({ url, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
+	/**
+	 * @param {Object} config
+	 * @param {String} config.url optional url for connecting the client of cluster
+	 * @param {Number} config.connectTimeout optional connection timeout in miliseconds (Default: 5000)
+	 * @param {Number} config.maxRetries optional max connection retries (Default: 3)
+	 */
+	static async connect({ url, connectTimeout, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
 
 		if(conn)
 			return conn;
@@ -54,7 +60,7 @@ module.exports = class Redis {
 			conn = RedisLib.createCluster({
 				rootNodes: urls.map(clusterUrl => ({
 					url: this.formatUrl(clusterUrl),
-					socket: this.formatRetries(maxRetries)
+					socket: this.formatSocket(maxRetries, connectTimeout)
 				})),
 				useReplicas: true
 			});
@@ -68,7 +74,7 @@ module.exports = class Redis {
 
 			conn = RedisLib.createClient({
 				url: this.formatUrl(url),
-				socket: this.formatRetries(maxRetries)
+				socket: this.formatSocket(maxRetries, connectTimeout)
 			});
 		}
 
@@ -105,7 +111,7 @@ module.exports = class Redis {
 			: url;
 	}
 
-	static formatRetries(maxRetries) {
+	static formatSocket(maxRetries, connectTimeout) {
 
 		/*
 			Redis reconnectStrategy param:
@@ -118,6 +124,7 @@ module.exports = class Redis {
 		*/
 
 		return {
+			...connectTimeout && { connectTimeout }, // Default 5000 ms
 			reconnectStrategy: retries => this.retriesHandler(retries, maxRetries)
 		};
 	}

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -106,11 +106,12 @@ module.exports = class Redis {
 
 	static retriesHandler(retries, maxRetries) {
 
-		if(retries > maxRetries)
-			return new Error(`Max connection retries (${maxRetries}) reached.`);
-
+		// Redis retries count starts from 0
 		// Redis default retry strategy (adds 50 miliseconds of wait per retry with a max of 1000)
-		return Math.min(retries * 50, 1000);
+		if(retries < maxRetries)
+			return Math.min(retries * 50, 1000);
+
+		return new Error(`Max connection retries (${maxRetries}) reached.`);
 	}
 
 	static cleanConn() {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,16 +1,20 @@
 'use strict';
 
+const logger = require('lllog')();
+
 const RedisLib = require('@redis/client');
 
 const Events = require('@janiscommerce/events');
-
 const Settings = require('@janiscommerce/settings');
 
-const logger = require('lllog')();
+const RedisError = require('./redis-error');
 
 const SETTINGS_KEY = 'redis';
-
 const DEFAULT_MAX_RETRIES = 3;
+
+const REDIS_ERRORS = {
+	reconnectStrategyError: 'ReconnectStrategyError'
+};
 
 /** @type {import('@redis/client').RedisClientType | import('@redis/client').RedisClusterType} */
 let conn;
@@ -66,7 +70,17 @@ module.exports = class Redis {
 
 		conn.on('error', err => logger.error(`Redis Client Error - ${err.message}`));
 
-		await conn.connect();
+		try {
+
+			await conn.connect();
+
+		} catch(err) {
+
+			if(err.constructor.name === REDIS_ERRORS.reconnectStrategyError)
+				throw new RedisError(err.message, RedisError.codes.MAX_CONNECTION_RETRIES, err);
+
+			throw new RedisError(err.message, RedisError.codes.REDIS_ERROR, err);
+		}
 
 		Events.once('janiscommerce.ended', this.closeConnection);
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -10,6 +10,8 @@ const logger = require('lllog')();
 
 const SETTINGS_KEY = 'redis';
 
+const DEFAULT_MAX_RETRIES = 3;
+
 /** @type {import('@redis/client').RedisClientType | import('@redis/client').RedisClusterType} */
 let conn;
 
@@ -22,7 +24,7 @@ module.exports = class Redis {
 		return Settings.get(SETTINGS_KEY); // internal cache already implemented by Settings package
 	}
 
-	static async connect({ url } = {}) {
+	static async connect({ url, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
 
 		if(conn)
 			return conn;
@@ -43,7 +45,8 @@ module.exports = class Redis {
 
 			conn = RedisLib.createCluster({
 				rootNodes: urls.map(clusterUrl => ({
-					url: this.formatUrl(clusterUrl)
+					url: this.formatUrl(clusterUrl),
+					socket: this.formatRetries(maxRetries)
 				})),
 				useReplicas: true
 			});
@@ -56,7 +59,8 @@ module.exports = class Redis {
 				return;
 
 			conn = RedisLib.createClient({
-				url: this.formatUrl(url)
+				url: this.formatUrl(url),
+				socket: this.formatRetries(maxRetries)
 			});
 		}
 
@@ -81,6 +85,32 @@ module.exports = class Redis {
 		return url.indexOf('redis://') === -1
 			? `redis://${url}`
 			: url;
+	}
+
+	static formatRetries(maxRetries) {
+
+		/*
+			Redis reconnectStrategy param:
+			- If receives a number it will use that number as miliseconds to wait before retrying
+			- If receives a `false` it won't retry
+			- If receives a function it will send the retries count as param
+				- If function returns a Number, it will use that number as miliseconds to wait before retrying
+				- If function returns a `false` it won't retry anymore
+				- If function returns an Error, same as `false` it won't retry but will use the custom error
+		*/
+
+		return {
+			reconnectStrategy: retries => this.retriesHandler(retries, maxRetries)
+		};
+	}
+
+	static retriesHandler(retries, maxRetries) {
+
+		if(retries > maxRetries)
+			return new Error(`Max connection retries (${maxRetries}) reached.`);
+
+		// Redis default retry strategy (adds 50 miliseconds of wait per retry with a max of 1000)
+		return Math.min(retries * 50, 1000);
 	}
 
 	static cleanConn() {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -106,10 +106,9 @@ module.exports = class Redis {
 
 	static retriesHandler(retries, maxRetries) {
 
-		// Redis retries count starts from 0
-		// Redis default retry strategy (adds 50 miliseconds of wait per retry with a max of 1000)
-		if(retries < maxRetries)
-			return Math.min(retries * 50, 1000);
+		// Redis retries count starts from 0 and does not count the first try
+		if(retries < (maxRetries - 1))
+			return Math.min(retries * 50, 1000); // Redis default retry strategy (adds 50 miliseconds of wait per retry with a max of 1000)
 
 		return new Error(`Max connection retries (${maxRetries}) reached.`);
 	}

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -38,7 +38,7 @@ module.exports = class Redis {
 	 * @param {Number} config.connectTimeout optional connection timeout in miliseconds (Default: 5000)
 	 * @param {Number} config.maxRetries optional max connection retries (Default: 3)
 	 */
-	static async connect({ url, connectTimeout, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
+	static async connect({ url, connectTimeout, maxRetries } = {}) {
 
 		if(conn)
 			return conn;
@@ -112,6 +112,9 @@ module.exports = class Redis {
 	}
 
 	static formatSocket(maxRetries, connectTimeout) {
+
+		if(!maxRetries && maxRetries !== 0)
+			maxRetries = DEFAULT_MAX_RETRIES;
 
 		/*
 			Redis reconnectStrategy param:

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -28,6 +28,10 @@ module.exports = class Redis {
 		return Settings.get(SETTINGS_KEY); // internal cache already implemented by Settings package
 	}
 
+	static get errorCodes() {
+		return RedisError.codes;
+	}
+
 	static async connect({ url, maxRetries = DEFAULT_MAX_RETRIES } = {}) {
 
 		if(conn)

--- a/tests/redis.js
+++ b/tests/redis.js
@@ -222,8 +222,7 @@ describe('Redis', () => {
 			// Every retry returns the retry count by 50
 			assert.deepStrictEqual(reconnectStrategy(0), 0);
 			assert.deepStrictEqual(reconnectStrategy(1), 50);
-			assert.deepStrictEqual(reconnectStrategy(2), 100);
-			assert.deepStrictEqual(reconnectStrategy(3), new Error('Max connection retries (3) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(2), new Error('Max connection retries (3) reached.'));
 		});
 
 		it('Should use the recevied maxRetries when its received', async () => {
@@ -258,8 +257,7 @@ describe('Redis', () => {
 			const { reconnectStrategy } = RedisLib.createClient.lastCall.lastArg.socket;
 
 			// Every retry returns the retry count by 50
-			assert.deepStrictEqual(reconnectStrategy(0), 0);
-			assert.deepStrictEqual(reconnectStrategy(1), new Error('Max connection retries (1) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(0), new Error('Max connection retries (1) reached.'));
 		});
 	});
 

--- a/tests/redis.js
+++ b/tests/redis.js
@@ -220,10 +220,10 @@ describe('Redis', () => {
 			const { reconnectStrategy } = RedisLib.createClient.lastCall.lastArg.socket;
 
 			// Every retry returns the retry count by 50
+			assert.deepStrictEqual(reconnectStrategy(0), 0);
 			assert.deepStrictEqual(reconnectStrategy(1), 50);
 			assert.deepStrictEqual(reconnectStrategy(2), 100);
-			assert.deepStrictEqual(reconnectStrategy(3), 150);
-			assert.deepStrictEqual(reconnectStrategy(4), new Error('Max connection retries (3) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(3), new Error('Max connection retries (3) reached.'));
 		});
 
 		it('Should use the recevied maxRetries when its received', async () => {
@@ -258,8 +258,8 @@ describe('Redis', () => {
 			const { reconnectStrategy } = RedisLib.createClient.lastCall.lastArg.socket;
 
 			// Every retry returns the retry count by 50
-			assert.deepStrictEqual(reconnectStrategy(1), 50);
-			assert.deepStrictEqual(reconnectStrategy(2), new Error('Max connection retries (1) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(0), 0);
+			assert.deepStrictEqual(reconnectStrategy(1), new Error('Max connection retries (1) reached.'));
 		});
 	});
 

--- a/tests/redis.js
+++ b/tests/redis.js
@@ -30,6 +30,17 @@ describe('Redis', () => {
 		Redis.cleanConn();
 	});
 
+	describe('Error Codes', () => {
+
+		it('Should return the Redis Error code', async () => {
+			assert.deepStrictEqual(Redis.errorCodes.REDIS_ERROR, RedisError.codes.REDIS_ERROR);
+		});
+
+		it('Should return the Max connection retries error', async () => {
+			assert.deepStrictEqual(Redis.errorCodes.MAX_CONNECTION_RETRIES, RedisError.codes.MAX_CONNECTION_RETRIES);
+		});
+	});
+
 	describe('Client Mode', () => {
 
 		beforeEach(() => {

--- a/tests/redis.js
+++ b/tests/redis.js
@@ -222,7 +222,8 @@ describe('Redis', () => {
 			// Every retry returns the retry count by 50
 			assert.deepStrictEqual(reconnectStrategy(0), 0);
 			assert.deepStrictEqual(reconnectStrategy(1), 50);
-			assert.deepStrictEqual(reconnectStrategy(2), new Error('Max connection retries (3) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(2), 100);
+			assert.deepStrictEqual(reconnectStrategy(3), new Error('Max connection retries (3) reached.'));
 		});
 
 		it('Should use the recevied maxRetries when its received', async () => {
@@ -257,7 +258,8 @@ describe('Redis', () => {
 			const { reconnectStrategy } = RedisLib.createClient.lastCall.lastArg.socket;
 
 			// Every retry returns the retry count by 50
-			assert.deepStrictEqual(reconnectStrategy(0), new Error('Max connection retries (1) reached.'));
+			assert.deepStrictEqual(reconnectStrategy(0), 0);
+			assert.deepStrictEqual(reconnectStrategy(1), new Error('Max connection retries (1) reached.'));
 		});
 	});
 


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JCN-470
- https://janiscommerce.atlassian.net/browse/JCN-471

## Descripción del requerimiento
- Modificar el metodo connect() para que throwee al detectar un error en Redis, para evitar que el proceso cuelgue el codigo indefinidamente

## Descripción de la solución
- Se modificó el metodo `connect()` para que use el `reconnectStrategy` nativo de Redis para configurar un limite de reintentos, por default es 3, si este limite se supera, throwea un error en lugar de seguir intentando indefinidamente

## Prueba realizada
![scr](https://github.com/janis-commerce/redis/assets/19476574/d875fa0c-6a4d-4be6-b7e3-becd7a2469cc)

## Changelog
```
### Added
- `config.maxRetries` param in `connect()` method for connection retries when it fails, default value 3.
- `config.connectTimeout` param in `connect()` method for custom connection timeout in ms, default value 5000
- Error codes for better error handling
```